### PR TITLE
catch Trello::Error and fail without killing the whole process

### DIFF
--- a/lib/trello_api.rb
+++ b/lib/trello_api.rb
@@ -18,6 +18,9 @@ class TrelloApi
     else
       set_card_name(card_id, name_with_updated_hours)
     end
+  rescue Trello::Error => e
+    notify_airbrake e
+    false
   end
 
   def get_card_name(card_id)
@@ -59,5 +62,9 @@ class TrelloApi
 
   def update_hours_in_name(name, total_hours)
     Trello::CardParser.new(name).update_hours_in_name(total_hours)
+  end
+
+  def notify_airbrake(err)
+    Airbrake.notify(err)
   end
 end

--- a/spec/lib/trello_api_spec.rb
+++ b/spec/lib/trello_api_spec.rb
@@ -28,6 +28,19 @@ describe TrelloApi do
 
       expect(res).to eql false
     end
+
+    it 'returns false on Trello::Error to notify failure and let process continue' do
+      res = client.update_card_hours('123456', 0.5)
+
+      expect(res).to eql false
+    end
+
+    it 'notifies airbrake on Trello::Error' do
+      expect(client).to receive(:update_card_hours).and_call_original
+      expect(client).to receive(:notify_airbrake)
+
+      res = client.update_card_hours('123456', 0.5)
+    end
   end
 
   context '#create_comment', :vcr do


### PR DESCRIPTION
handle errors where the card id wasn't found